### PR TITLE
refactor of default server binding address

### DIFF
--- a/TcpServer.js
+++ b/TcpServer.js
@@ -71,7 +71,7 @@ TcpServer.prototype.listen = function() : TcpServer {
   var callback = args[1];
 
   var port = options.port;
-  var host = options.host || 'localhost';
+  var host = options.host || '0.0.0.0';
 
   if (callback) {
     this.on('listening', callback);


### PR DESCRIPTION
As you can see in official API from [net module](https://nodejs.org/api/net.html#net_server_listen_port_hostname_backlog_callback) default address to listen for server is '0.0.0.0'. In your module you are using 'localhost' so I made that PR for being consistent with official API.