### PR TITLE
Fixes #29 ios socket callback id matchup

### DIFF
--- a/examples/rctsockets/index.ios.js
+++ b/examples/rctsockets/index.ios.js
@@ -48,6 +48,10 @@ class RctSockets extends Component {
       socket.on('error', (error) => {
         this.updateChatter('error ' + error);
       });
+
+      socket.on('close', (error) => {
+        this.updateChatter('server client closed ' + (error ? error : ''));
+      });
     }).listen(serverPort, () => {
       this.updateChatter('opened server on ' + JSON.stringify(server.address()));
     });

--- a/ios/TcpSockets.m
+++ b/ios/TcpSockets.m
@@ -127,16 +127,20 @@ RCT_EXPORT_METHOD(listen:(nonnull NSNumber*)cId
                                                     body:base64String];
 }
 
-- (void)onClose:(TcpSocketClient*) client withError:(NSError *)err
+- (void)onClose:(NSNumber*) clientID withError:(NSError *)err
 {
+    TcpSocketClient* client = [self findClient:clientID];
+    if (!client) {
+        RCTLogError(@"onClose: unrecognized client id %@", clientID)
+    }
+
     if (err) {
-      [self onError:client withError:err];
+        [self onError:client withError:err];
     }
 
     [self.bridge.eventDispatcher sendDeviceEventWithName:[NSString stringWithFormat:@"tcp-%@-close", client.id]
                                                     body:err == nil ? @NO : @YES];
 
-    client.clientDelegate = nil;
     [_clients removeObjectForKey:client.id];
 }
 
@@ -174,7 +178,6 @@ RCT_EXPORT_METHOD(listen:(nonnull NSNumber*)cId
     if (!client) return;
 
     [client destroy];
-    [_clients removeObjectForKey:cId];
 }
 
 -(NSNumber*)getNextId {


### PR DESCRIPTION
GCDAsyncSocket shares the delegate between the listening socket and the connected socket, so the socket client's id will not match up with the correct disconnect message and cause problems on ios.

Now we store the socket client's id in the GCDAsyncSocket's userData blob, In order to ensure that disconnect messages when sent to javascript are tagged with the correct id, and received by the correct javascript socket object.