### PR TITLE
Address createJSModules being removed in RN 0.47

### DIFF
--- a/android/src/main/java/com/peel/react/TcpSocketsModule.java
+++ b/android/src/main/java/com/peel/react/TcpSocketsModule.java
@@ -28,7 +28,7 @@ public final class TcpSocketsModule implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
RN 0.47 removes createJSModules from ReactPackage. Change this code to not be an @Override so it will still be present on older versions but not prevent compilation on 0.47.