### PR TITLE
Set callback after write can cause callback being skipped

### DIFF
--- a/ios/TcpSocketClient.m
+++ b/ios/TcpSocketClient.m
@@ -180,10 +180,10 @@ NSString *const RCTTCPErrorDomain = @"RCTTCPErrorDomain";
 - (void) writeData:(NSData *)data
           callback:(RCTResponseSenderBlock)callback
 {
-    [_tcpSocket writeData:data withTimeout:-1 tag:_sendTag];
     if (callback) {
         [self setPendingSend:callback forKey:@(_sendTag)];
     }
+    [_tcpSocket writeData:data withTimeout:-1 tag:_sendTag];
 
     _sendTag++;
 


### PR DESCRIPTION
When didWriteDataWithTag is called but callback is not yet pushed to
pendingSends dictionary, it will be skipped and cause stream to hang
forever.