### PR TITLE
Throw should be a callback

### DIFF
--- a/TcpSocket.js
+++ b/TcpSocket.js
@@ -357,7 +357,10 @@ TcpSocket.prototype._write = function(buffer: any, encoding: ?String, callback: 
   var self = this;
 
   if (this._state === STATE.DISCONNECTED) {
-    throw new Error('Socket is not connected.');
+    if (typeof callback !== 'function') {
+      throw new Error('Socket is not connected.');
+    }
+    return callback(new Error('Socket is not connected.'));
   } else if (this._state === STATE.CONNECTING) {
     // we're ok, GCDAsyncSocket handles queueing internally
   }


### PR DESCRIPTION
Please review and close if it's not adequate. Please also explain briefly in that case.
- Backwards compatible change
- Passes back the error through callback if such callback exists and has `function` type