### PR TITLE
Fix net.createServer to comply with official API

### DIFF
--- a/TcpSockets.js
+++ b/TcpSockets.js
@@ -13,7 +13,10 @@ var ipRegex = require('ip-regex');
 var Socket = require('./TcpSocket');
 var Server = require('./TcpServer');
 
-exports.createServer = function(connectionListener: (socket: Socket)  => void) : Server {
+exports.createServer = function(opts: any, connectionListener: (socket: Socket)  => void) : Server {
+  if (typeof opts === 'function' && !connectionListener) {
+    return new Server(opts);
+  }
   return new Server(connectionListener);
 };
 


### PR DESCRIPTION
The node.js API is officially `net.createServer([opts][, connectionListener])`, meaning that it should support an optional `opts` argument.

I added support for the `opts` argument, even though it is ignored at the moment, because in some cases when using this library, `net.createServer(opts, listener)` would crash because it would attempt to call `opts` as a function.