### PR TITLE
Fix the global.process issue in TcpSocket.js while preserving debugging

### DIFF
--- a/TcpSocket.js
+++ b/TcpSocket.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-global.process = require('process'); // needed to make stream-browserify happy
+global.process = global.process || require('process'); // needed to make stream-browserify happy
 var Buffer = global.Buffer = global.Buffer || require('buffer').Buffer;
 
 var util = require('util');

--- a/TcpSocket.js
+++ b/TcpSocket.js
@@ -8,7 +8,11 @@
 
 'use strict';
 
-global.process = global.process || require('process'); // needed to make stream-browserify happy
+// if global.process does not have nextTick, redefine global.process.
+if(!(global.process && global.process.nextTick)){
+  global.process = require('process'); // needed to make stream-browserify happy
+}
+
 var Buffer = global.Buffer = global.Buffer || require('buffer').Buffer;
 
 var util = require('util');

--- a/TcpSocket.js
+++ b/TcpSocket.js
@@ -73,7 +73,7 @@ TcpSocket.prototype._debug = function() {
   if (__DEV__) {
     var args = [].slice.call(arguments);
     args.unshift('socket-' + this._id);
-    console.log.apply(console, args);
+    //console.log.apply(console, args);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-tcp",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "node's net API for react-native",
   "main": "TcpSockets.js",
   "scripts": {


### PR DESCRIPTION
Fix the global.process issue in TcpSocket.js while preserving ability to debug with Chrome/vscode.

Overwrites global.process in TcpSocket.js only when one of the following is true:
- global.process does not exist 
- global.process does exist and global.process.nextTick does not exist.

