### PR TITLE
Сorrectly terminating the socket connection Android 7+

### DIFF
--- a/android/src/main/java/com/peel/react/TcpSocketManager.java
+++ b/android/src/main/java/com/peel/react/TcpSocketManager.java
@@ -157,6 +157,7 @@ public final class TcpSocketManager {
         Object socket = mClients.get(cId);
         if (socket != null) {
             if (socket instanceof AsyncSocket) {
+                ((AsyncSocket) socket).end();
                 ((AsyncSocket) socket).close();
             } else if (socket instanceof AsyncServerSocket) {
                 ((AsyncServerSocket) socket).stop();

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-tcp",
+  "name": "@hirurgo/react-native-tcp",
   "version": "3.3.0",
   "description": "node's net API for react-native",
   "main": "TcpSockets.js",


### PR DESCRIPTION
On our project we are faced with the problem of correctly terminating the socket connection on android above version 7.
This fix will help to avoid this problem.